### PR TITLE
rename `metalavaSignaturePublish` to `metalavaGenerateSignature`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ apply plugin: "me.tylerbwong.gradle.metalava"
 
 This plugin registers the following tasks:
 
-`metalavaSignaturePublish` - Generates a Metalava signature descriptor file at a specified location.
+`metalavaGenerateSignature` - Generates a Metalava signature descriptor file at a specified location.
 
 `metalavaCheckCompatibility` - Checks API compatibility between the code base and the current API.
 

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/plugin/MetalavaPlugin.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/plugin/MetalavaPlugin.kt
@@ -15,7 +15,7 @@ class MetalavaPlugin : Plugin<Project> {
                 val currentModule = module
                 MetalavaSignature.registerMetalavaSignatureTask(
                     project = this,
-                    name = "metalavaSignaturePublish",
+                    name = "metalavaGenerateSignature",
                     description = "Generates a Metalava signature descriptor file.",
                     extension = extension,
                     module = currentModule


### PR DESCRIPTION
Publish in the Gradle world is use extensively by ``maven-publish` so
that got me confused for a bit about whether this would publish a
signature somewhere (also because signature are part of maven
publications). I think `generateSignature` is less loaded and will
prevent some confusion