### PR TITLE
Set Android variant name for classpath discovery

### DIFF
--- a/plugin/api/0.1.6-SNAPSHOT.txt
+++ b/plugin/api/0.1.6-SNAPSHOT.txt
@@ -40,6 +40,7 @@ package me.tylerbwong.gradle.metalava.extension {
 
   public class MetalavaExtension {
     ctor public MetalavaExtension();
+    method public final String getAndroidVariantName();
     method public final me.tylerbwong.gradle.metalava.Documentation getDocumentation();
     method public final String getFilename();
     method public final me.tylerbwong.gradle.metalava.Format getFormat();
@@ -55,6 +56,7 @@ package me.tylerbwong.gradle.metalava.extension {
     method public final boolean getReportWarningsAsErrors();
     method public final me.tylerbwong.gradle.metalava.Signature getSignature();
     method public final String getVersion();
+    method public final void setAndroidVariantName(String p);
     method public final void setDocumentation(me.tylerbwong.gradle.metalava.Documentation p);
     method public final void setFilename(String p);
     method public final void setFormat(me.tylerbwong.gradle.metalava.Format p);
@@ -69,6 +71,7 @@ package me.tylerbwong.gradle.metalava.extension {
     method public final void setReportWarningsAsErrors(boolean p);
     method public final void setSignature(me.tylerbwong.gradle.metalava.Signature p);
     method public final void setVersion(String p);
+    property public final String androidVariantName;
     property public final me.tylerbwong.gradle.metalava.Documentation documentation;
     property public final String filename;
     property public final me.tylerbwong.gradle.metalava.Format format;

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Module.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Module.kt
@@ -1,6 +1,7 @@
 package me.tylerbwong.gradle.metalava
 
 import com.android.build.gradle.LibraryExtension
+import me.tylerbwong.gradle.metalava.extension.MetalavaExtension
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginConvention
@@ -14,12 +15,12 @@ internal sealed class Module {
     open val bootClasspath: Collection<File> = emptyList()
     abstract val compileClasspath: Collection<File>
 
-    class Android(private val extension: LibraryExtension) : Module() {
+    class Android(private val extension: LibraryExtension, private val variantName: String) : Module() {
         override val bootClasspath: Collection<File>
             get() = extension.bootClasspath
         override val compileClasspath: Collection<File>
             get() = extension.libraryVariants.find {
-                it.name.contains("debug", ignoreCase = true)
+                it.name.contains(variantName, ignoreCase = true)
             }?.getCompileClasspath(null)?.filter { it.exists() }?.files ?: emptyList()
     }
 
@@ -41,20 +42,19 @@ internal sealed class Module {
     }
 
     companion object {
-        internal val Project.module: Module
-            get() {
-                // Use findByName to avoid requiring consumers to have the Android Gradle plugin
-                // in their classpath when applying this plugin to a non-Android project
-                val libraryExtension = extensions.findByName("android")
-                val multiplatformExtension = extensions.findByType<KotlinMultiplatformExtension>()
-                val javaPluginConvention = convention.findPlugin<JavaPluginConvention>()
-                return when {
-                    libraryExtension != null && libraryExtension is LibraryExtension -> Android(libraryExtension)
-                    multiplatformExtension != null -> Multiplatform(multiplatformExtension)
-                    javaPluginConvention != null -> Java(javaPluginConvention)
-                    else -> throw GradleException("This module is currently not supported by the Metalava plugin")
-                }
+        internal fun Project.module(extension: MetalavaExtension): Module {
+            // Use findByName to avoid requiring consumers to have the Android Gradle plugin
+            // in their classpath when applying this plugin to a non-Android project
+            val libraryExtension = extensions.findByName("android")
+            val multiplatformExtension = extensions.findByType<KotlinMultiplatformExtension>()
+            val javaPluginConvention = convention.findPlugin<JavaPluginConvention>()
+            return when {
+                libraryExtension != null && libraryExtension is LibraryExtension -> Android(libraryExtension, extension.androidVariantName)
+                multiplatformExtension != null -> Multiplatform(multiplatformExtension)
+                javaPluginConvention != null -> Java(javaPluginConvention)
+                else -> throw GradleException("This module is currently not supported by the Metalava plugin")
             }
+        }
 
         internal fun File.checkDirectory(validExtensions: Collection<String>): Boolean {
             return if (isFile) {

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
@@ -90,4 +90,10 @@ open class MetalavaExtension {
      * Promote all API lint warnings to errors.
      */
     var reportLintsAsErrors = false
+
+    /**
+     * For Android modules defines which variant should be used to resolve classpath when Metalava
+     * generates or checks API.
+     */
+    var androidVariantName = "debug"
 }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/plugin/MetalavaPlugin.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/plugin/MetalavaPlugin.kt
@@ -12,7 +12,7 @@ class MetalavaPlugin : Plugin<Project> {
         with(target) {
             val extension = extensions.create("metalava", MetalavaExtension::class.java)
             afterEvaluate {
-                val currentModule = module
+                val currentModule = module(extension)
                 MetalavaSignature.registerMetalavaSignatureTask(
                     project = this,
                     name = "metalavaGenerateSignature",


### PR DESCRIPTION
In my projects I remove `debug` variant for library modules and use `release` as the only one. Unfortunately there is no way in the plugin to specify that. This PR adds an extension point for Android module classpath discovery.