### PR TITLE
Add Java runtime JAR to classpath in Java modules

### DIFF
--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Module.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Module.kt
@@ -33,6 +33,10 @@ internal sealed class Module {
     }
 
     class Java(private val convention: JavaPluginConvention) : Module() {
+        override val bootClasspath: Collection<File>
+            get() = File(System.getProperty("java.home")).walkTopDown()
+                .toList()
+                .filter { it.exists() && it.name == "rt.jar" }
         override val compileClasspath: Collection<File>
             get() = convention.sourceSets
                 .filter { it.name.contains("main", ignoreCase = true) }


### PR DESCRIPTION
Without JDK classpath available classes that are not present in Kotlin and are strictly JDK do not show in the generated API.

```kotlin
public class Sample {
  public val jdkClass: BigDecimal = BigDecimal.ZERO
}
```

Before:
```
public final class Sample {
  ctor public Sample();
  method public error.NonExistentClass getJdkClass();
  property public final error.NonExistentClass jdkClass;
}
```

After:
```
public final class Sample {
  ctor public Sample();
  method public java.math.BigDecimal getJdkClass();
  property public final java.math.BigDecimal jdkClass;
}
```

I considered using `--jdk-home` argument instead but I think it's nicer to use properties that are already available in `Module` class. Also `--jdk-home` can get in conflicts with with `--sdk-home` if both would be used in the future.