### PR TITLE
Add releasetype configuration for compatibility check

### DIFF
--- a/plugin/api/0.2.0-SNAPSHOT.txt
+++ b/plugin/api/0.2.0-SNAPSHOT.txt
@@ -43,9 +43,9 @@ package me.tylerbwong.gradle.metalava.extension {
     method public final boolean getInputKotlinNulls();
     method public final org.gradle.api.JavaVersion getJavaSourceLevel();
     method public final String? getMetalavaJarPath();
-    method public final boolean getOmitCommonPackages();
     method public final boolean getOutputDefaultValues();
     method public final boolean getOutputKotlinNulls();
+    method public final String getReleaseType();
     method public final boolean getReportLintsAsErrors();
     method public final boolean getReportWarningsAsErrors();
     method public final me.tylerbwong.gradle.metalava.Signature getSignature();
@@ -58,9 +58,9 @@ package me.tylerbwong.gradle.metalava.extension {
     method public final void setInputKotlinNulls(boolean inputKotlinNulls);
     method public final void setJavaSourceLevel(org.gradle.api.JavaVersion javaSourceLevel);
     method public final void setMetalavaJarPath(String? metalavaJarPath);
-    method public final void setOmitCommonPackages(boolean omitCommonPackages);
     method public final void setOutputDefaultValues(boolean outputDefaultValues);
     method public final void setOutputKotlinNulls(boolean outputKotlinNulls);
+    method public final void setReleaseType(String releaseType);
     method public final void setReportLintsAsErrors(boolean reportLintsAsErrors);
     method public final void setReportWarningsAsErrors(boolean reportWarningsAsErrors);
     method public final void setSignature(me.tylerbwong.gradle.metalava.Signature signature);
@@ -74,9 +74,9 @@ package me.tylerbwong.gradle.metalava.extension {
     property public final boolean inputKotlinNulls;
     property public final org.gradle.api.JavaVersion javaSourceLevel;
     property public final String? metalavaJarPath;
-    property public final boolean omitCommonPackages;
     property public final boolean outputDefaultValues;
     property public final boolean outputKotlinNulls;
+    property public final String releaseType;
     property public final boolean reportLintsAsErrors;
     property public final boolean reportWarningsAsErrors;
     property public final me.tylerbwong.gradle.metalava.Signature signature;

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
@@ -53,12 +53,6 @@ open class MetalavaExtension {
     var outputDefaultValues = true
 
     /**
-     * Skip common package prefixes like java.lang.* and kotlin.* in signature files, along with
-     * packages for well known annotations like @Nullable and @NonNull.
-     */
-    var omitCommonPackages = true
-
-    /**
      * Whether the signature files should include a comment listing the format version of the
      * signature file.
      */
@@ -96,4 +90,13 @@ open class MetalavaExtension {
      * generates or checks API.
      */
     var androidVariantName = "debug"
+
+    /**
+     * Customization of the severities to apply when doing compatibility checking
+     * "current" will identify all changes (i.e. removals and additions)
+     * "released" will identify only removals and additions of abstract methods
+     * The default is "current"
+     */
+
+    var releaseType = "current"
 }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
@@ -92,11 +92,10 @@ open class MetalavaExtension {
     var androidVariantName = "debug"
 
     /**
-     * Customization of the severities to apply when doing compatibility checking
-     * "current" will identify all changes (i.e. removals and additions)
-     * "released" will identify only removals and additions of abstract methods
-     * The default is "current"
+     * Customization of the severities to apply when doing compatibility checking.
+     * "current" will identify all changes (i.e. removals and additions).
+     * "released" will identify only removals and additions of abstract methods.
+     * The default is "current".
      */
-
     var releaseType = "current"
 }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaCheckCompatibility.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaCheckCompatibility.kt
@@ -43,7 +43,7 @@ internal object MetalavaCheckCompatibility : MetalavaTaskContainer() {
                         "--no-banner",
                         "--format=${extension.format}",
                         "--source-files", tempFilename,
-                        "--check-compatibility:api:current", extension.filename,
+                        "--check-compatibility:api:${extension.releaseType}", extension.filename,
                         "--input-kotlin-nulls=${extension.inputKotlinNulls.flagValue}"
                     ) + extension.reportWarningsAsErrors.flag("--warnings-as-errors") +
                             extension.reportLintsAsErrors.flag("--lints-as-errors") + hidePackages + hideAnnotations

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
@@ -49,7 +49,6 @@ internal object MetalavaSignature : MetalavaTaskContainer() {
                         "--classpath", fullClasspath,
                         "--output-kotlin-nulls=${extension.outputKotlinNulls.flagValue}",
                         "--output-default-values=${extension.outputDefaultValues.flagValue}",
-                        "--omit-common-packages=${extension.omitCommonPackages.flagValue}",
                         "--include-signature-version=${extension.includeSignatureVersion.flagValue}"
                     ) + sourcePaths + hidePackages + hideAnnotations
 


### PR DESCRIPTION
remove --omit-common-packages flag as it is not supported by metalava 1.0.0-alpha04

add releasetype configuration for compatibility check