### PR TITLE
fix: add task inputs to trigger task execution on change

### DIFF
--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaCheckCompatibility.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaCheckCompatibility.kt
@@ -32,25 +32,23 @@ internal object MetalavaCheckCompatibility : MetalavaTaskContainer() {
                 inputs.file(extension.filename)
                 outputs.file(tempFilename)
 
-                doFirst {
-                    // TODO Consolidate flags between tasks
-                    val hidePackages =
-                        extension.hiddenPackages.flatMap { listOf("--hide-package", it) }
-                    val hideAnnotations =
-                        extension.hiddenAnnotations.flatMap { listOf("--hide-annotation", it) }
+                // TODO Consolidate flags between tasks
+                val hidePackages =
+                    extension.hiddenPackages.flatMap { listOf("--hide-package", it) }
+                val hideAnnotations =
+                    extension.hiddenAnnotations.flatMap { listOf("--hide-annotation", it) }
 
-                    val args: List<String> = listOf(
-                        "--no-banner",
-                        "--format=${extension.format}",
-                        "--source-files", tempFilename,
-                        "--check-compatibility:api:${extension.releaseType}", extension.filename,
-                        "--input-kotlin-nulls=${extension.inputKotlinNulls.flagValue}"
-                    ) + extension.reportWarningsAsErrors.flag("--warnings-as-errors") +
-                            extension.reportLintsAsErrors.flag("--lints-as-errors") + hidePackages + hideAnnotations
+                val args: List<String> = listOf(
+                    "--no-banner",
+                    "--format=${extension.format}",
+                    "--source-files", tempFilename,
+                    "--check-compatibility:api:${extension.releaseType}", extension.filename,
+                    "--input-kotlin-nulls=${extension.inputKotlinNulls.flagValue}"
+                ) + extension.reportWarningsAsErrors.flag("--warnings-as-errors") +
+                        extension.reportLintsAsErrors.flag("--lints-as-errors") + hidePackages + hideAnnotations
 
-                    isIgnoreExitValue = false
-                    setArgs(args)
-                }
+                isIgnoreExitValue = false
+                setArgs(args)
             }
             // Projects that apply this plugin should include API compatibility checking as part of their regular checks
             afterEvaluate { tasks.findByName("check")?.dependsOn(checkCompatibilityTask) }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaCheckCompatibility.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaCheckCompatibility.kt
@@ -30,25 +30,32 @@ internal object MetalavaCheckCompatibility : MetalavaTaskContainer() {
                 // If both the current API and temp API have not changed since last run, then
                 // consider this task UP-TO-DATE
                 inputs.file(extension.filename)
+                inputs.property("format", extension.format)
+                inputs.property("inputKotlinNulls", extension.inputKotlinNulls.flagValue)
+                inputs.property("releaseType", extension.releaseType)
+                inputs.property("hiddenPackages", extension.hiddenPackages)
+                inputs.property("hiddenAnnotations", extension.hiddenAnnotations)
                 outputs.file(tempFilename)
 
-                // TODO Consolidate flags between tasks
-                val hidePackages =
-                    extension.hiddenPackages.flatMap { listOf("--hide-package", it) }
-                val hideAnnotations =
-                    extension.hiddenAnnotations.flatMap { listOf("--hide-annotation", it) }
+                doFirst {
+                    // TODO Consolidate flags between tasks
+                    val hidePackages =
+                        extension.hiddenPackages.flatMap { listOf("--hide-package", it) }
+                    val hideAnnotations =
+                        extension.hiddenAnnotations.flatMap { listOf("--hide-annotation", it) }
 
-                val args: List<String> = listOf(
-                    "--no-banner",
-                    "--format=${extension.format}",
-                    "--source-files", tempFilename,
-                    "--check-compatibility:api:${extension.releaseType}", extension.filename,
-                    "--input-kotlin-nulls=${extension.inputKotlinNulls.flagValue}"
-                ) + extension.reportWarningsAsErrors.flag("--warnings-as-errors") +
-                        extension.reportLintsAsErrors.flag("--lints-as-errors") + hidePackages + hideAnnotations
+                    val args: List<String> = listOf(
+                        "--no-banner",
+                        "--format=${extension.format}",
+                        "--source-files", tempFilename,
+                        "--check-compatibility:api:${extension.releaseType}", extension.filename,
+                        "--input-kotlin-nulls=${extension.inputKotlinNulls.flagValue}"
+                    ) + extension.reportWarningsAsErrors.flag("--warnings-as-errors") +
+                            extension.reportLintsAsErrors.flag("--lints-as-errors") + hidePackages + hideAnnotations
 
-                isIgnoreExitValue = false
-                setArgs(args)
+                    isIgnoreExitValue = false
+                    setArgs(args)
+                }
             }
             // Projects that apply this plugin should include API compatibility checking as part of their regular checks
             afterEvaluate { tasks.findByName("check")?.dependsOn(checkCompatibilityTask) }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
@@ -31,30 +31,28 @@ internal object MetalavaSignature : MetalavaTaskContainer() {
                 inputs.files(sources)
                 outputs.file(filename)
 
-                doFirst {
-                    val fullClasspath = (module.bootClasspath + module.compileClasspath).joinToString(File.pathSeparator)
+                val fullClasspath = (module.bootClasspath + module.compileClasspath).joinToString(File.pathSeparator)
 
-                    val sourcePaths = listOf("--source-path") + sources.joinToString(File.pathSeparator)
-                    val hidePackages =
-                        extension.hiddenPackages.flatMap { listOf("--hide-package", it) }
-                    val hideAnnotations =
-                        extension.hiddenAnnotations.flatMap { listOf("--hide-annotation", it) }
+                val sourcePaths = listOf("--source-path") + sources.joinToString(File.pathSeparator)
+                val hidePackages =
+                    extension.hiddenPackages.flatMap { listOf("--hide-package", it) }
+                val hideAnnotations =
+                    extension.hiddenAnnotations.flatMap { listOf("--hide-annotation", it) }
 
-                    val args: List<String> = listOf(
-                        "${extension.documentation}",
-                        "--no-banner",
-                        "--format=${extension.format}",
-                        "${extension.signature}", filename,
-                        "--java-source", "${extension.javaSourceLevel}",
-                        "--classpath", fullClasspath,
-                        "--output-kotlin-nulls=${extension.outputKotlinNulls.flagValue}",
-                        "--output-default-values=${extension.outputDefaultValues.flagValue}",
-                        "--include-signature-version=${extension.includeSignatureVersion.flagValue}"
-                    ) + sourcePaths + hidePackages + hideAnnotations
+                val args: List<String> = listOf(
+                    "${extension.documentation}",
+                    "--no-banner",
+                    "--format=${extension.format}",
+                    "${extension.signature}", filename,
+                    "--java-source", "${extension.javaSourceLevel}",
+                    "--classpath", fullClasspath,
+                    "--output-kotlin-nulls=${extension.outputKotlinNulls.flagValue}",
+                    "--output-default-values=${extension.outputDefaultValues.flagValue}",
+                    "--include-signature-version=${extension.includeSignatureVersion.flagValue}"
+                ) + sourcePaths + hidePackages + hideAnnotations
 
-                    isIgnoreExitValue = true
-                    setArgs(args)
-                }
+                isIgnoreExitValue = true
+                setArgs(args)
             }
         }
     }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
@@ -29,30 +29,41 @@ internal object MetalavaSignature : MetalavaTaskContainer() {
                     .filter { it.isDirectory && (it.name == "java" || it.name == "kotlin") }
                     .toList()
                 inputs.files(sources)
+                inputs.property("documentation", extension.documentation)
+                inputs.property("format", extension.format)
+                inputs.property("signature", extension.signature)
+                inputs.property("javaSourceLevel", extension.javaSourceLevel)
+                inputs.property("outputKotlinNulls", extension.outputKotlinNulls.flagValue)
+                inputs.property("outputDefaultValues", extension.outputDefaultValues.flagValue)
+                inputs.property("includeSignatureVersion", extension.includeSignatureVersion.flagValue)
+                inputs.property("hiddenPackages", extension.hiddenPackages)
+                inputs.property("hiddenAnnotations", extension.hiddenAnnotations)
                 outputs.file(filename)
 
-                val fullClasspath = (module.bootClasspath + module.compileClasspath).joinToString(File.pathSeparator)
+                doFirst {
+                    val fullClasspath = (module.bootClasspath + module.compileClasspath).joinToString(File.pathSeparator)
 
-                val sourcePaths = listOf("--source-path") + sources.joinToString(File.pathSeparator)
-                val hidePackages =
-                    extension.hiddenPackages.flatMap { listOf("--hide-package", it) }
-                val hideAnnotations =
-                    extension.hiddenAnnotations.flatMap { listOf("--hide-annotation", it) }
+                    val sourcePaths = listOf("--source-path") + sources.joinToString(File.pathSeparator)
+                    val hidePackages =
+                        extension.hiddenPackages.flatMap { listOf("--hide-package", it) }
+                    val hideAnnotations =
+                        extension.hiddenAnnotations.flatMap { listOf("--hide-annotation", it) }
 
-                val args: List<String> = listOf(
-                    "${extension.documentation}",
-                    "--no-banner",
-                    "--format=${extension.format}",
-                    "${extension.signature}", filename,
-                    "--java-source", "${extension.javaSourceLevel}",
-                    "--classpath", fullClasspath,
-                    "--output-kotlin-nulls=${extension.outputKotlinNulls.flagValue}",
-                    "--output-default-values=${extension.outputDefaultValues.flagValue}",
-                    "--include-signature-version=${extension.includeSignatureVersion.flagValue}"
-                ) + sourcePaths + hidePackages + hideAnnotations
+                    val args: List<String> = listOf(
+                        "${extension.documentation}",
+                        "--no-banner",
+                        "--format=${extension.format}",
+                        "${extension.signature}", filename,
+                        "--java-source", "${extension.javaSourceLevel}",
+                        "--classpath", fullClasspath,
+                        "--output-kotlin-nulls=${extension.outputKotlinNulls.flagValue}",
+                        "--output-default-values=${extension.outputDefaultValues.flagValue}",
+                        "--include-signature-version=${extension.includeSignatureVersion.flagValue}"
+                    ) + sourcePaths + hidePackages + hideAnnotations
 
-                isIgnoreExitValue = true
-                setArgs(args)
+                    isIgnoreExitValue = true
+                    setArgs(args)
+                }
             }
         }
     }


### PR DESCRIPTION
We had an issue where releaseType was being cached, task stayed "UP-TO-DATE" after changing the releaseType. By removing doFirst changing the releaseType, and the other extension parameters provided as arguments for the task, will trigger the task to be executed. 