### PR TITLE
Add Android taskvariant support & fix sourcePath bug

### DIFF
--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Module.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Module.kt
@@ -13,6 +13,7 @@ internal sealed class Module {
 
     open val bootClasspath: Collection<File> = emptyList()
     abstract val compileClasspath: Collection<File>
+    open val taskVariants: Collection<String> = emptyList()
 
     class Android(private val extension: LibraryExtension, private val variantName: String) : Module() {
         override val bootClasspath: Collection<File>
@@ -21,6 +22,8 @@ internal sealed class Module {
             get() = extension.libraryVariants.find {
                 it.name.contains(variantName, ignoreCase = true)
             }?.getCompileClasspath(null)?.filter { it.exists() }?.files ?: emptyList()
+        override val taskVariants: Collection<String>
+            get() = extension.libraryVariants.map { it.name }
     }
 
     class Multiplatform(private val extension: KotlinMultiplatformExtension) : Module() {

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/plugin/MetalavaPlugin.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/plugin/MetalavaPlugin.kt
@@ -6,6 +6,7 @@ import me.tylerbwong.gradle.metalava.task.MetalavaCheckCompatibility
 import me.tylerbwong.gradle.metalava.task.MetalavaSignature
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import java.util.Locale
 
 class MetalavaPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -13,18 +14,25 @@ class MetalavaPlugin : Plugin<Project> {
             val extension = extensions.create("metalava", MetalavaExtension::class.java)
             afterEvaluate {
                 val currentModule = module(extension)
-                MetalavaSignature.registerMetalavaSignatureTask(
-                    project = this,
-                    name = "metalavaGenerateSignature",
-                    description = "Generates a Metalava signature descriptor file.",
-                    extension = extension,
-                    module = currentModule
-                )
-                MetalavaCheckCompatibility.registerMetalavaCheckCompatibilityTask(
-                    project = this,
-                    extension = extension,
-                    module = currentModule
-                )
+                val taskVariants = currentModule.taskVariants.ifEmpty { listOf("") }
+                taskVariants.forEach {
+                    val variantName = it.capitalize(Locale.getDefault())
+
+                    MetalavaSignature.registerMetalavaSignatureTask(
+                        project = this,
+                        name = "metalavaGenerateSignature$variantName",
+                        description = "Generates a Metalava signature descriptor file.",
+                        extension = extension,
+                        module = currentModule
+                    )
+
+                    MetalavaCheckCompatibility.registerMetalavaCheckCompatibilityTask(
+                        project = this,
+                        taskVariant = variantName,
+                        extension = extension,
+                        module = currentModule
+                    )
+                }
             }
         }
     }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaCheckCompatibility.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaCheckCompatibility.kt
@@ -6,12 +6,17 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.JavaExec
 
 internal object MetalavaCheckCompatibility : MetalavaTaskContainer() {
-    fun registerMetalavaCheckCompatibilityTask(project: Project, extension: MetalavaExtension, module: Module) {
+    fun registerMetalavaCheckCompatibilityTask(
+        project: Project,
+        taskVariant: String = "",
+        extension: MetalavaExtension,
+        module: Module
+    ) {
         with(project) {
             val tempFilename = layout.buildDirectory.file("metalava/current.txt").get().asFile.absolutePath
             val generateTempMetalavaSignatureTask = MetalavaSignature.registerMetalavaSignatureTask(
                 project = this,
-                name = "metalavaGenerateTempSignature",
+                name = "metalavaGenerateTempSignature$taskVariant",
                 description = """
                     Generates a Metalava signature descriptor file in the project build directory for API compatibility 
                     checking.
@@ -20,7 +25,7 @@ internal object MetalavaCheckCompatibility : MetalavaTaskContainer() {
                 module = module,
                 filename = tempFilename
             )
-            val checkCompatibilityTask = tasks.register("metalavaCheckCompatibility", JavaExec::class.java) {
+            val checkCompatibilityTask = tasks.register("metalavaCheckCompatibility$taskVariant", JavaExec::class.java) {
                 group = "verification"
                 description = "Checks API compatibility between the code base and the current or release API."
                 mainClass.set("com.android.tools.metalava.Driver")

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
@@ -6,7 +6,6 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
-import java.util.Locale
 
 internal object MetalavaSignature : MetalavaTaskContainer() {
     private val sourceLanguageDirectoryNames = listOf("java", "kotlin")
@@ -28,17 +27,9 @@ internal object MetalavaSignature : MetalavaTaskContainer() {
                 mainClass.set("com.android.tools.metalava.Driver")
                 classpath(extension.metalavaJarPath?.let { files(it) } ?: getMetalavaClasspath(extension.version))
 
-                val sourceFiles = extension.sourcePaths.flatMap { sourcePath ->
-                    file(sourcePath)
-                        .walk()
-                        .onEnter {
-                            extension.ignoreSourcePaths.none { ignoredDirectoryName ->
-                                ignoredDirectoryName.equals(it.name, ignoreCase = true)
-                            }
-                        }
-                        .filter { it.isDirectory }
-                        .filter { it.name.toLowerCase(Locale.getDefault()) in sourceLanguageDirectoryNames }
-                        .toList()
+                val sourceFiles = mutableSetOf<File>()
+                for (directory in extension.sourcePaths) {
+                    sourceFiles.add(file(directory))
                 }
 
                 inputs.files(sourceFiles)


### PR DESCRIPTION
This PR addresses two issues:

- The extension's `sourcePaths` handling saw issues where a build-time directory (specified in the `sourcePaths` list) would not be added by the "walk" code because of that code being executed in the Configuration step. That is, when it executed, the path didn't actually exist yet, and so was dropped. Looking at the code, it seems unnecessary, to me, to walk the file tree, particularly as the `metalava` component itself (to which we're passing the args) will do that anyway; ie, a `sourcePaths = ["src"]` will include all sub-dirs anyway, so the code in this plugin need not do that.
- Adds in support for creating `metalavaX` tasks (ie `metalavaCheckCompatibilityDebug`) based on the `buildTypes` in the android extension. Adding [new build variants](https://developer.android.com/studio/build/build-variants) is supported here. This makes it possible, in components that use the `metalava-gradle` plugin, to depend on the appropriate task based on build type. A  use would be code-generation creating Java source that needs to also to be parsed by the `metalava-plugin`. It was impossible to do this before, with a single `metalavaCheckCompatibility` task.