### PR TITLE
Expose addSourcePaths function for directory dependencies

### DIFF
--- a/plugin/api/0.2.2-SNAPSHOT.txt
+++ b/plugin/api/0.2.2-SNAPSHOT.txt
@@ -33,7 +33,8 @@ package me.tylerbwong.gradle.metalava {
 package me.tylerbwong.gradle.metalava.extension {
 
   public class MetalavaExtension {
-    ctor public MetalavaExtension();
+    ctor @javax.inject.Inject public MetalavaExtension(org.gradle.api.model.ObjectFactory objects);
+    method public final void addSourcePaths(Object sourcePaths);
     method public final String getAndroidVariantName();
     method public final me.tylerbwong.gradle.metalava.Documentation getDocumentation();
     method public final boolean getEnforceCheck();

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
@@ -119,8 +119,8 @@ open class MetalavaExtension @Inject constructor(
      * Add a directory (or multiple) in which to search for source files.
      * The given paths are evaluated as per [org.gradle.api.Project.files].
      */
-    fun addSourcePaths(sourcePath: Any) {
-        sourcePathsFileCollection.from(sourcePath)
+    fun addSourcePaths(sourcePaths: Any) {
+        sourcePathsFileCollection.from(sourcePaths)
     }
 
     /**

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
@@ -4,8 +4,12 @@ import me.tylerbwong.gradle.metalava.Documentation
 import me.tylerbwong.gradle.metalava.Format
 import me.tylerbwong.gradle.metalava.Signature
 import org.gradle.api.JavaVersion
+import org.gradle.api.model.ObjectFactory
+import javax.inject.Inject
 
-open class MetalavaExtension {
+open class MetalavaExtension @Inject constructor(
+    objects: ObjectFactory,
+) {
     /**
      * The version of Metalava to use.
      */
@@ -103,9 +107,21 @@ open class MetalavaExtension {
      * The directories to search for source files. An exception will be thrown is the named
      * directories are not direct children of the project root. The default is "src".
      *
+     * @see addSourcePath
      * @see ignoreSourcePaths
      */
     var sourcePaths = mutableSetOf("src")
+
+    /** Internal. Do not use. */
+    internal val sourcePathsFileCollection = objects.fileCollection()
+
+    /**
+     * Add a directory in which to search for source files.
+     * The given path is evaluated as per [org.gradle.api.Project.files].
+     */
+    fun addSourcePath(sourcePath: Any) {
+        sourcePathsFileCollection.from(sourcePath)
+    }
 
     /**
      * The sub-directories of each directory specified by [sourcePaths] that should not be searched

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
@@ -107,7 +107,7 @@ open class MetalavaExtension @Inject constructor(
      * The directories to search for source files. An exception will be thrown is the named
      * directories are not direct children of the project root. The default is "src".
      *
-     * @see addSourcePath
+     * @see addSourcePaths
      * @see ignoreSourcePaths
      */
     var sourcePaths = mutableSetOf("src")
@@ -116,10 +116,10 @@ open class MetalavaExtension @Inject constructor(
     internal val sourcePathsFileCollection = objects.fileCollection()
 
     /**
-     * Add a directory in which to search for source files.
-     * The given path is evaluated as per [org.gradle.api.Project.files].
+     * Add a directory (or multiple) in which to search for source files.
+     * The given paths are evaluated as per [org.gradle.api.Project.files].
      */
-    fun addSourcePath(sourcePath: Any) {
+    fun addSourcePaths(sourcePath: Any) {
         sourcePathsFileCollection.from(sourcePath)
     }
 

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
@@ -60,8 +60,10 @@ internal object MetalavaSignature : MetalavaTaskContainer() {
                 doFirst {
                     val fullClasspath = (module.bootClasspath + module.compileClasspath.files).joinToString(File.pathSeparator)
 
-                    val sourcePaths = (sourceFiles +
-                        extension.sourcePathsFileCollection.elements.get().map { it.asFile })
+                    val sourcePaths = (
+                        sourceFiles +
+                            extension.sourcePathsFileCollection.elements.get().map { it.asFile }
+                        )
                         .also { files ->
                             val nonExistentDirs = files.filter { !it.exists() }
                             require(nonExistentDirs.isEmpty()) {

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
@@ -52,17 +52,17 @@ internal object MetalavaSignature : MetalavaTaskContainer() {
                     val sourcePaths = (
                         sourceFiles +
                             extension.sourcePathsFileCollection.elements.get().map { it.asFile }
+                                .also { files ->
+                                    val nonExistentDirs = files.filter { !it.exists() }
+                                    require(nonExistentDirs.isEmpty()) {
+                                        "Specified source path doesn't exist: $nonExistentDirs"
+                                    }
+                                    val nonDirectories = files.filter { !it.isDirectory }
+                                    require(nonDirectories.isEmpty()) {
+                                        "Specified source path isn't a directory: $nonDirectories"
+                                    }
+                                }
                         )
-                        .also { files ->
-                            val nonExistentDirs = files.filter { !it.exists() }
-                            require(nonExistentDirs.isEmpty()) {
-                                "Specified source path doesn't exist: $nonExistentDirs"
-                            }
-                            val nonDirectories = files.filter { !it.isDirectory }
-                            require(nonDirectories.isEmpty()) {
-                                "Specified source path isn't a directory: $nonDirectories"
-                            }
-                        }
                         .joinToString(File.pathSeparator)
 
                     val hidePackages =

--- a/plugin/src/test/kotlin/me/tylerbwong/gradle/metalava/MetalavaGradlePluginTest.kt
+++ b/plugin/src/test/kotlin/me/tylerbwong/gradle/metalava/MetalavaGradlePluginTest.kt
@@ -71,7 +71,7 @@ class MetalavaGradlePluginTest {
         val result = gradleRunner.build()
         assertTrue(result.output.contains("not supported by the Metalava Gradle plugin"))
     }
-  
+
     @Test
     fun `check addSourcePaths propagates task dependency`() {
         buildscriptFile = testProjectDir.newFile("build.gradle.kts").apply {

--- a/plugin/src/test/kotlin/me/tylerbwong/gradle/metalava/MetalavaGradlePluginTest.kt
+++ b/plugin/src/test/kotlin/me/tylerbwong/gradle/metalava/MetalavaGradlePluginTest.kt
@@ -71,8 +71,7 @@ class MetalavaGradlePluginTest {
         val result = gradleRunner.build()
         assertTrue(result.output.contains("not supported by the Metalava Gradle plugin"))
     }
-
-
+  
     @Test
     fun `check addSourcePaths propagates task dependency`() {
         buildscriptFile = testProjectDir.newFile("build.gradle.kts").apply {

--- a/plugin/src/test/kotlin/me/tylerbwong/gradle/metalava/MetalavaGradlePluginTest.kt
+++ b/plugin/src/test/kotlin/me/tylerbwong/gradle/metalava/MetalavaGradlePluginTest.kt
@@ -74,7 +74,7 @@ class MetalavaGradlePluginTest {
 
 
     @Test
-    fun `check addSourcePath propagates task dependency`() {
+    fun `check addSourcePaths propagates task dependency`() {
         buildscriptFile = testProjectDir.newFile("build.gradle.kts").apply {
             appendText(
                 """
@@ -99,7 +99,7 @@ class MetalavaGradlePluginTest {
                     }
                     
                     metalava {
-                        addSourcePath(customSourceGeneratingTaskProvider.map { it.outputs.files })
+                        addSourcePaths(customSourceGeneratingTaskProvider.map { it.outputs.files })
                     }
                 """
             )


### PR DESCRIPTION
This adds `fun addSourcePaths(sourcePaths: Any)` to the plugin's extension. It can be used when including source directories for generated code, which often come as `FileCollection`s with task dependencies. Using a `ConfigurableFileCollection` as a task input lets us automatically run those dependency tasks when applicable.

A practical example is including a `KotlinSourceSet`'s source directories in the signature file:
```kotlin
metalava {
  val consumerSourceSetNames = setOf("androidMain", "desktopMain")
  val kotlinSourceFileCollection = files(paths = emptyArray<Any>()) {
    consumerSourceSetNames
      .flatMap {
        val sourceSet = kotlin.sourceSets.getByName(it)
        sourceSet.dependsOn + sourceSet
      }
      .forEach { from(it.kotlin.sourceDirectories) }
  }

  addSourcePaths(kotlinSourceFileCollection)
}
```
This will ensure even generated code properly gets seen by Metalava.