### PR TITLE
Express compile classpath as a FileCollection, propagating dependencies

### DIFF
--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaSignature.kt
@@ -43,6 +43,7 @@ internal object MetalavaSignature : MetalavaTaskContainer() {
                         .toList()
                 }
 
+                inputs.files(module.compileClasspath)
                 inputs.files(sourceFiles)
                 inputs.property("documentation", extension.documentation)
                 inputs.property("format", extension.format)
@@ -56,7 +57,7 @@ internal object MetalavaSignature : MetalavaTaskContainer() {
                 outputs.file(filename)
 
                 doFirst {
-                    val fullClasspath = (module.bootClasspath + module.compileClasspath).joinToString(File.pathSeparator)
+                    val fullClasspath = (module.bootClasspath + module.compileClasspath.files).joinToString(File.pathSeparator)
 
                     val sourcePaths = listOf("--source-path") + sourceFiles.joinToString(File.pathSeparator)
 


### PR DESCRIPTION
Currently, `Module.compileClasspath` is a `Collection<File>`. This works for holding the set of files in the classpath. However, Gradle stores information about how those files are generated in a `FileCollection`, which is generally how plugins expose compile classpaths. When a task depends on a `FileCollection`, these generation dependencies are propagated to the task. Without those dependencies, the task won't generate those files as needed, which causes #9.
This changes `Module.compileClasspath` to be a `FileCollection`, and adds it as an input to the signature generation task. As a result, tasks that generate code for the compile classpath will be run when running `metalavaGenerateSignature`, which is desired.

Side note: I agree with many of the changes in #28. This is a smaller fix that addresses the first issue described in that PR.