### PR TITLE
Allow configuring hiddenAnnotations

### DIFF
--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
@@ -75,7 +75,7 @@ open class MetalavaExtension @Inject constructor(
     /**
      * Treat any elements annotated with the given annotation as hidden.
      */
-    val hiddenAnnotations = mutableSetOf<String>()
+    var hiddenAnnotations = mutableSetOf<String>()
 
     /**
      * Whether the signature file being read should be interpreted as having encoded its types using


### PR DESCRIPTION
> Cannot set the value of read-only property 'hiddenAnnotations' for extension 'metalava' of type me.tylerbwong.gradle.metalava.extension.MetalavaExtension.

Or is there any other way?