### PR TITLE
Add task to compare the current API against the current signature file

### DIFF
--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Module.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Module.kt
@@ -99,5 +99,8 @@ internal sealed class Module {
                 listFiles()?.all { it.checkDirectory(validExtensions) } ?: false
             }
         }
+
+        internal fun Project.getTemporarySignatureFilePath() =
+            layout.buildDirectory.file("metalava/current.txt").get().asFile.absolutePath
     }
 }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/plugin/MetalavaPlugin.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/plugin/MetalavaPlugin.kt
@@ -1,9 +1,11 @@
 package me.tylerbwong.gradle.metalava.plugin
 
 import me.tylerbwong.gradle.metalava.Module
+import me.tylerbwong.gradle.metalava.Module.Companion.getTemporarySignatureFilePath
 import me.tylerbwong.gradle.metalava.Module.Companion.module
 import me.tylerbwong.gradle.metalava.extension.MetalavaExtension
 import me.tylerbwong.gradle.metalava.task.MetalavaCheckCompatibility
+import me.tylerbwong.gradle.metalava.task.MetalavaCompareApiWithCurrent
 import me.tylerbwong.gradle.metalava.task.MetalavaSignature
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -44,12 +46,31 @@ class MetalavaPlugin : Plugin<Project> {
             variantName = variantName
         )
 
+        MetalavaSignature.registerMetalavaSignatureTask(
+            project = project,
+            extension = metalavaExtension,
+            module = module,
+            taskName = "metalavaGenerateTempSignature",
+            taskDescription = "Generates a Metalava signature descriptor file in the project build directory for API compatibility checking.",
+            variantName = variantName,
+            filename = project.getTemporarySignatureFilePath()
+        )
+
         MetalavaCheckCompatibility.registerMetalavaCheckCompatibilityTask(
             project = project,
             extension = metalavaExtension,
             module = module,
             taskName = "metalavaCheckCompatibility",
             taskDescription = "Checks API compatibility between the code base and the current or release API.",
+            variantName = variantName,
+        )
+
+        MetalavaCompareApiWithCurrent.registerMetalavaCompareApiWithCurrent(
+            project = project,
+            extension = metalavaExtension,
+            module = module,
+            taskName = "metalavaCompareApiWithCurrent",
+            taskDescription = "Compares the current signature file with a temporary signature file, generated from the current API.",
             variantName = variantName
         )
     }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaCompareApiWithCurrent.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaCompareApiWithCurrent.kt
@@ -1,0 +1,56 @@
+package me.tylerbwong.gradle.metalava.task
+
+import me.tylerbwong.gradle.metalava.Module
+import me.tylerbwong.gradle.metalava.Module.Companion.getTemporarySignatureFilePath
+import me.tylerbwong.gradle.metalava.extension.MetalavaExtension
+import org.gradle.api.Project
+import java.io.File
+import java.io.FileReader
+
+internal object MetalavaCompareApiWithCurrent : MetalavaTaskContainer() {
+    fun registerMetalavaCompareApiWithCurrent(
+        project: Project,
+        extension: MetalavaExtension,
+        @Suppress("UNUSED_PARAMETER") module: Module,
+        taskName: String,
+        taskDescription: String,
+        variantName: String?
+    ) {
+        with(project) {
+            tasks.register(getFullTaskName(taskName, variantName)) {
+                group = "verification"
+                description = taskDescription
+                dependsOn(project.tasks.findByName(getFullTaskName("metalavaGenerateTempSignature", variantName)))
+
+                val tempSignatureFilename = project.getTemporarySignatureFilePath()
+
+                // Use temp signature file for incremental Gradle task output
+                // If both the current API and temp API have not changed since last run, then
+                // consider this task UP-TO-DATE
+                inputs.file(extension.filename)
+                inputs.property("format", extension.format)
+                inputs.property("inputKotlinNulls", extension.inputKotlinNulls.flagValue)
+                inputs.property("apiType", extension.apiType)
+                inputs.property("hiddenPackages", extension.hiddenPackages)
+                inputs.property("hiddenAnnotations", extension.hiddenAnnotations)
+                outputs.file(tempSignatureFilename)
+
+                doFirst {
+                    val signatureFile = layout.projectDirectory.file(extension.filename).asFile
+                    require(signatureFile.exists()) { "MetalavaCompareApiWithCurrent 1 Couldn't find \"${signatureFile}\"." }
+                    require(File(tempSignatureFilename).exists()) { "MetalavaCompareApiWithCurrent 2 Couldn't find \"${tempSignatureFilename}\"." }
+
+                    var existingText: String
+                    FileReader(signatureFile).use { existingText = it.readText() }
+
+                    var tempFileText: String
+                    FileReader(tempSignatureFilename).use { tempFileText = it.readText() }
+
+                    check(existingText == tempFileText) {
+                        "Signature files don't match. Compare \"${signatureFile.absolutePath}\" and \"$tempSignatureFilename\"."
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaTaskContainer.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaTaskContainer.kt
@@ -14,12 +14,13 @@ internal abstract class MetalavaTaskContainer {
     }
 
     protected fun Project.getMetalavaClasspath(version: String): FileCollection {
-        val configuration = configurations.findByName("metalava") ?: configurations.create("metalava").apply {
-            val dependency = this@getMetalavaClasspath.dependencies.create(
-                "com.android.tools.metalava:metalava:$version"
-            )
-            dependencies.add(dependency)
-        }
+        val configuration =
+            configurations.findByName("metalava") ?: configurations.create("metalava").apply {
+                val dependency = this@getMetalavaClasspath.dependencies.create(
+                    "com.android.tools.metalava:metalava:$version"
+                )
+                dependencies.add(dependency)
+            }
         return files(configuration)
     }
 


### PR DESCRIPTION
The removal of `api:current` resulted in the local developer workflow requiring that they were aware of what tasks should be executed and when. This means that there is a requirement that there is some way to verify that the existing signature file correctly reflects what the API looks like. That is, there was no longer a simple way for either a developer, locally, or on CI, to verify that the signature file had been updated following an addition.

This PR adds a new task `metalavaCompareApiWithCurrent` which can be run to conduct a simple equality check that the existing signature file matches a 'temp generated' signature file (from the _current_ API). It simply throws if those two files don't match, printing the paths of those files.