### PR TITLE
Address slow configuration when plugin is applied

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@
 - Be as descriptive as possible when submitting new pull requests
 - Link any related issues the pull request might be addressing
 - This project uses [ktlint](https://github.com/pinterest/ktlint). (`./gradlew ktlintCheck` should succeed)
+- If the pull request modifies the public API, regenerate the api file by running `./gradlew metalavaGenerateSignature`
 
 ### Issues
 

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Module.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Module.kt
@@ -63,10 +63,17 @@ internal sealed class Module {
     }
 
     class Java(private val extension: JavaPluginExtension) : Module() {
-        override val bootClasspath: Collection<File>
-            get() = File(System.getProperty("java.home")).walkTopDown()
-                .toList()
-                .filter { it.exists() && it.name == "rt.jar" }
+        override val bootClasspath: Collection<File> by lazy {
+            listOfNotNull(
+                System.getProperty("sun.boot.class.path")
+                    ?.let { File(it) }
+                    ?.takeIf { it.exists() },
+                File(System.getProperty("java.home"))
+                    .resolve("jre${File.separator}lib${File.separator}rt.jar")
+                    .takeIf { it.exists() }
+            )
+        }
+
         override fun compileClasspath(variant: String?): FileCollection {
             return extension.sourceSets
                 .filter { it.name.contains("main", ignoreCase = true) }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/plugin/MetalavaPlugin.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/plugin/MetalavaPlugin.kt
@@ -59,9 +59,9 @@ internal class MetalavaPlugin @Inject constructor(
         // Projects that apply this plugin should include API compatibility checking as part of their regular checks.
         // However, it may be that source dirs are generated only after some other build phase, and so the
         // association with 'check' should be configurable.
-        project.afterEvaluate {
+        project.tasks.named("check").configure {
             if (metalavaExtension.enforceCheck.get()) {
-                tasks.findByName("check")?.dependsOn(checkCompatibilityTask)
+                dependsOn(checkCompatibilityTask)
             }
         }
     }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaGenerateSignatureTask.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaGenerateSignatureTask.kt
@@ -18,7 +18,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.register
 import org.gradle.workers.WorkerExecutor
 import java.io.File
 import javax.inject.Inject
@@ -123,12 +123,13 @@ internal abstract class MetalavaGenerateSignatureTask @Inject constructor(
                 jarPath = extension.metalavaJarPath.get().ifEmpty { null },
                 version = extension.version.get(),
             )
-            project.tasks.create<MetalavaGenerateSignatureTask>(taskName) {
+            val bootClasspathProvider = project.provider { module.bootClasspath }
+            project.tasks.register<MetalavaGenerateSignatureTask>(taskName) {
                 this.metalavaClasspath.from(metalavaClasspath)
                 sourcePaths.from(extension.sourcePaths)
                 filename.set(extension.filename)
                 shouldRunGenerateSignature.set(true)
-                bootClasspath.from(module.bootClasspath)
+                bootClasspath.from(bootClasspathProvider)
                 compileClasspath.from(module.compileClasspath(variantName))
                 documentation.set(extension.documentation)
                 format.set(extension.format)


### PR DESCRIPTION
This resolves #53.

Build scan results, copied from #53:

Before my changes (if you run a build scan on metalava project today, running only ":plugin:tasks" task):
* `gradlew tasks`: https://scans.gradle.com/s/tvha27uguhq5w/performance/configuration
  * 2 tasks created immediately
  * 1 task (check) created during configuration, by the plugin - due to tasks.findByName("check")
  * 42 seconds spent in Model Configuration and 1st afterEvaluate
* `gradlew metalavaGen`: https://scans.gradle.com/s/ttufjgxpjhe3s/performance/build
  * takes 38 seconds:
  * 30 seconds in configuration
  * 7 seconds in task execution

After my changes:
* `gradlew tasks`: https://scans.gradle.com/s/5xl2hhhjberkk/performance/configuration
  * 0 tasks created immediately
  * Plugin does not create any additional tasks during configuration - due to switching to tasks.named("check")
  * 0.9 seconds spent in Model Configuration and afterEvaluate
* `gradlew metalavaGen`: https://scans.gradle.com/s/iejkcx2uhzbfe/performance/build
  * takes 40 seconds:
  * 16 seconds in configuration (calculating task graph)
  * 24 seconds executing the metalava task