### PR TITLE
Upgrade metalava to version 1.0.0-alpha10

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,6 @@ plugins {
 ...
 
 metalava {
-    documentation.set(Documentation.PUBLIC)
-    outputKotlinNulls.set(false)
-    includeSignatureVersion.set(false)
     ...
 }
 ```

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Documentation.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Documentation.kt
@@ -3,6 +3,7 @@ package me.tylerbwong.gradle.metalava
 /**
  * Flags to determine documented API by visibility modifier.
  */
+@Deprecated("This has been removed and is not currently used.")
 enum class Documentation(private val flagValue: String) {
     /**
      * Only include elements that are public.

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/extension/MetalavaExtension.kt
@@ -16,7 +16,7 @@ open class MetalavaExtension @Inject constructor(
     /**
      * The version of Metalava to use.
      */
-    val version: Property<String> = objectFactory.property { set("1.0.0-alpha08") }
+    val version: Property<String> = objectFactory.property { set("1.0.0-alpha10") }
 
     /**
      * A custom Metalava JAR location path to use instead of the embedded dependency.
@@ -48,6 +48,7 @@ open class MetalavaExtension @Inject constructor(
     /**
      * @see Documentation
      */
+    @Deprecated("This has been removed and is not currently used.")
     val documentation: Property<Documentation> = objectFactory.property {
         set(Documentation.PROTECTED)
     }
@@ -61,17 +62,20 @@ open class MetalavaExtension @Inject constructor(
      * Controls whether nullness annotations should be formatted as in Kotlin (with "?" for nullable
      * types, "" for non-nullable types, and "!" for unknown. The default is true.
      */
+    @Deprecated("This has been removed and is not currently used.")
     val outputKotlinNulls: Property<Boolean> = objectFactory.property { set(true) }
 
     /**
      * Controls whether default values should be included in signature files. The default is true.
      */
+    @Deprecated("This has been removed and is not currently used.")
     val outputDefaultValues: Property<Boolean> = objectFactory.property { set(true) }
 
     /**
      * Whether the signature files should include a comment listing the format version of the
      * signature file. The default is true.
      */
+    @Deprecated("This has been removed and is not currently used.")
     val includeSignatureVersion: Property<Boolean> = objectFactory.property { set(true) }
 
     /**

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaCheckCompatibilityTask.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaCheckCompatibilityTask.kt
@@ -47,11 +47,9 @@ internal abstract class MetalavaCheckCompatibilityTask @Inject constructor(
         val hideAnnotations = hiddenAnnotations.get().flatMap { listOf("--hide-annotation", it) }
 
         val args: List<String> = listOf(
-            "--no-banner",
             "--format=${format.get()}",
             "--source-files", tempFilename.get(),
             "--check-compatibility:${apiType.get()}:released", filename.get(),
-            "--input-kotlin-nulls=${inputKotlinNulls.get().flagValue}"
         ) + reportWarningsAsErrors.get().flag("--warnings-as-errors") + reportLintsAsErrors.get()
             .flag("--lints-as-errors") + hidePackages + hideAnnotations
         executeMetalavaWork(args)
@@ -87,13 +85,9 @@ internal abstract class MetalavaCheckCompatibilityTask @Inject constructor(
                 shouldRunGenerateSignature.set(false)
                 bootClasspath.from(bootClasspathProvider)
                 compileClasspath.from(module.compileClasspath(variantName))
-                documentation.set(extension.documentation)
                 format.set(extension.format)
                 signature.set(extension.signature)
                 javaSourceLevel.set(extension.javaSourceLevel)
-                outputKotlinNulls.set(extension.outputKotlinNulls)
-                outputDefaultValues.set(extension.outputDefaultValues)
-                includeSignatureVersion.set(extension.includeSignatureVersion)
                 hiddenPackages.set(extension.hiddenPackages)
                 hiddenAnnotations.set(extension.hiddenAnnotations)
                 apiType.set(extension.apiType)

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaGenerateSignatureTask.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaGenerateSignatureTask.kt
@@ -1,6 +1,5 @@
 package me.tylerbwong.gradle.metalava.task
 
-import me.tylerbwong.gradle.metalava.Documentation
 import me.tylerbwong.gradle.metalava.Module
 import me.tylerbwong.gradle.metalava.Signature
 import me.tylerbwong.gradle.metalava.extension.MetalavaExtension
@@ -45,22 +44,10 @@ internal abstract class MetalavaGenerateSignatureTask @Inject constructor(
     abstract val sourcePaths: ConfigurableFileCollection
 
     @get:Input
-    abstract val documentation: Property<Documentation>
-
-    @get:Input
     abstract val signature: Property<Signature>
 
     @get:Input
     abstract val javaSourceLevel: Property<JavaVersion>
-
-    @get:Input
-    abstract val outputKotlinNulls: Property<Boolean>
-
-    @get:Input
-    abstract val outputDefaultValues: Property<Boolean>
-
-    @get:Input
-    abstract val includeSignatureVersion: Property<Boolean>
 
     @get:Input
     abstract val shouldRunGenerateSignature: Property<Boolean>
@@ -92,15 +79,10 @@ internal abstract class MetalavaGenerateSignatureTask @Inject constructor(
         }
 
         val args: List<String> = listOf(
-            "${documentation.get()}",
-            "--no-banner",
             "--format=${format.get()}",
             "${signature.get()}", filenameOverride ?: filename.get(),
             "--java-source", "${javaSourceLevel.get()}",
             "--classpath", fullClasspath,
-            "--output-kotlin-nulls=${outputKotlinNulls.get().flagValue}",
-            "--output-default-values=${outputDefaultValues.get().flagValue}",
-            "--include-signature-version=${includeSignatureVersion.get().flagValue}",
             "--source-path", sourcePaths,
         ) + hidePackages + hideAnnotations + keepFileFlags
         executeMetalavaWork(args, awaitWork)
@@ -131,13 +113,9 @@ internal abstract class MetalavaGenerateSignatureTask @Inject constructor(
                 shouldRunGenerateSignature.set(true)
                 bootClasspath.from(bootClasspathProvider)
                 compileClasspath.from(module.compileClasspath(variantName))
-                documentation.set(extension.documentation)
                 format.set(extension.format)
                 signature.set(extension.signature)
                 javaSourceLevel.set(extension.javaSourceLevel)
-                outputKotlinNulls.set(extension.outputKotlinNulls)
-                outputDefaultValues.set(extension.outputDefaultValues)
-                includeSignatureVersion.set(extension.includeSignatureVersion)
                 hiddenPackages.set(extension.hiddenPackages)
                 hiddenAnnotations.set(extension.hiddenAnnotations)
                 keepFilename.set(extension.keepFilename)

--- a/samples/groovy-java/build.gradle
+++ b/samples/groovy-java/build.gradle
@@ -10,6 +10,4 @@ java {
 
 metalava {
     filename = "api/$name-api.txt"
-    outputKotlinNulls = false
-    includeSignatureVersion = false
 }


### PR DESCRIPTION
Upgrading to metalava 1.0.0-alpha10 some of the options have been removed from the tool.

I could not find a replacement on the documentation so I had to remove them.

In particular I removed:

`--no-banner` this has been marked as deprecated and is ignored
`--output-kotlin-nulls` this has been removed
`--output-default-values`  this has been removed
`--include-signature-version`  this has been removed
`--<documentation>` this has been removed

this should close https://github.com/tylerbwong/metalava-gradle/issues/83