### PR TITLE
Use numeric Metalava format versions

### DIFF
--- a/plugin/api/0.5.0.txt
+++ b/plugin/api/0.5.0.txt
@@ -2,14 +2,12 @@
 package me.tylerbwong.gradle.metalava {
 
   public enum Format {
-    method public java.lang.String toString();
     enum_constant public static final me.tylerbwong.gradle.metalava.Format V2;
     enum_constant public static final me.tylerbwong.gradle.metalava.Format V3;
     enum_constant public static final me.tylerbwong.gradle.metalava.Format V4;
   }
 
   public enum Signature {
-    method public java.lang.String toString();
     enum_constant public static final me.tylerbwong.gradle.metalava.Signature API;
     enum_constant public static final me.tylerbwong.gradle.metalava.Signature DEX_API;
     enum_constant public static final me.tylerbwong.gradle.metalava.Signature DEX_API_MAPPING;

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Format.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Format.kt
@@ -1,10 +1,12 @@
 package me.tylerbwong.gradle.metalava
 
 /** Sets the output signature file format to be the given version. */
-public enum class Format {
-    V2,
-    V3,
-    V4;
+public enum class Format(
+    private val version: String
+) {
+    V2("2.0"),
+    V3("3.0"),
+    V4("4.0");
 
-    override fun toString(): String = name.lowercase()
+    override fun toString(): String = version
 }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Format.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Format.kt
@@ -1,10 +1,8 @@
 package me.tylerbwong.gradle.metalava
 
 /** Sets the output signature file format to be the given version. */
-public enum class Format(
-    internal val version: String
-) {
+public enum class Format(internal val version: String) {
     V2("2.0"),
     V3("3.0"),
-    V4("4.0");
+    V4("4.0"),
 }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Format.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Format.kt
@@ -2,11 +2,9 @@ package me.tylerbwong.gradle.metalava
 
 /** Sets the output signature file format to be the given version. */
 public enum class Format(
-    private val version: String
+    internal val version: String
 ) {
     V2("2.0"),
     V3("3.0"),
     V4("4.0");
-
-    override fun toString(): String = version
 }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Signature.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Signature.kt
@@ -1,9 +1,7 @@
 package me.tylerbwong.gradle.metalava
 
 /** Flags to determine which type of signature file to generate. */
-public enum class Signature(
-    internal val argument: String
-) {
+public enum class Signature(internal val argument: String) {
     /** Generate a signature descriptor file. */
     API("--api"),
 
@@ -22,5 +20,5 @@ public enum class Signature(
     DEX_API_MAPPING("--dex-api-mapping"),
 
     /** Generate a signature descriptor file for APIs that have been removed. */
-    REMOVED_API("--removed-api");
+    REMOVED_API("--removed-api"),
 }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Signature.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/Signature.kt
@@ -1,7 +1,9 @@
 package me.tylerbwong.gradle.metalava
 
 /** Flags to determine which type of signature file to generate. */
-public enum class Signature(private val signature: String) {
+public enum class Signature(
+    internal val argument: String
+) {
     /** Generate a signature descriptor file. */
     API("--api"),
 
@@ -21,6 +23,4 @@ public enum class Signature(private val signature: String) {
 
     /** Generate a signature descriptor file for APIs that have been removed. */
     REMOVED_API("--removed-api");
-
-    override fun toString(): String = signature
 }

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/BaseMetalavaTask.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/BaseMetalavaTask.kt
@@ -59,7 +59,7 @@ internal abstract class BaseMetalavaTask(
         val hideAnnotations = hiddenAnnotations.get().flatMap { listOf("--hide-annotation", it) }
         val apiCompatAnnotations =
             apiCompatAnnotations.get().flatMap { listOf("--api-compat-annotation", it) }
-        return listOf("--format=${format.get()}") +
+        return listOf("--format=${format.get().version}") +
             hidePackages +
             hideAnnotations +
             apiCompatAnnotations +

--- a/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaGenerateSignatureTask.kt
+++ b/plugin/src/main/kotlin/me/tylerbwong/gradle/metalava/task/MetalavaGenerateSignatureTask.kt
@@ -83,7 +83,7 @@ constructor(objectFactory: ObjectFactory, workerExecutor: WorkerExecutor) :
 
         val args: List<String> =
             listOf(
-                "${signature.get()}",
+                signature.get().argument,
                 filenameOverride ?: filename.get(),
                 "--java-source",
                 "${javaSourceLevel.get()}",

--- a/plugin/src/test/kotlin/me/tylerbwong/gradle/metalava/MetalavaGradlePluginTest.kt
+++ b/plugin/src/test/kotlin/me/tylerbwong/gradle/metalava/MetalavaGradlePluginTest.kt
@@ -43,6 +43,44 @@ class MetalavaGradlePluginTest {
         assertTrue(result.output.contains("BUILD SUCCESSFUL"))
     }
 
+    @ParameterizedTest
+    @ValueSource(
+        strings =
+            [
+                "1.0.0-alpha10",
+                "1.0.0-alpha11",
+                "1.0.0-alpha12",
+                "1.0.0-alpha13",
+                "1.0.0-alpha14",
+                "1.0.0-alpha15",
+            ]
+    )
+    fun `format argument works across Metalava versions`(metalavaVersion: String) {
+        buildscriptFile.apply {
+            appendText(
+                """
+                    allprojects {
+                        repositories {
+                            google()
+                            mavenCentral()
+                        }
+                    }
+
+                    plugins {
+                        `java-library`
+                        id("me.tylerbwong.gradle.metalava")
+                    }
+
+                    metalava {
+                        version = "$metalavaVersion"
+                    }
+                """
+            )
+        }
+        val result = runner("metalavaGenerateSignature").build()
+        assertTrue(result.output.contains("BUILD SUCCESSFUL"))
+    }
+
     @Test
     fun `check plugin reports warning for unsupported module`() {
         buildscriptFile.apply {


### PR DESCRIPTION
## Summary

- emit numeric Metalava signature format versions such as `4.0` instead of legacy labels such as `v4`
- cover every Metalava version from the plugin's alpha10 default through alpha15
- preserve compatibility with older releases while supporting alpha15, which removed format labels
- scope creep: make `Format` and `Signature` CLI values explicit instead of relying on implicit `toString()` conversion

Fixes #181.

## Compatibility

Numeric format specifiers were introduced in Metalava `1.0.0-alpha09`:
https://android.googlesource.com/platform/tools/metalava/+/53f7185f10314f785b874093d37d8c279803cdec

The plugin defaults to alpha10, so all versions supported by the integration matrix accept numeric specifiers.

Legacy labels such as `v4` were removed in Metalava `1.0.0-alpha15`:
https://android.googlesource.com/platform/tools/metalava/+/0049e9ca31b7bea6801013123f5acf2705e788e7

## Testing

```text
./gradlew :plugin:test --tests 'me.tylerbwong.gradle.metalava.MetalavaGradlePluginTest.format argument works across Metalava versions'
```

Tested Metalava `1.0.0-alpha10` through `1.0.0-alpha15`.
